### PR TITLE
Fix MultiValueArithmeticDriver<T> component enum and add my Resonite path to the csproj

### DIFF
--- a/Components/Transform/Drivers/MultiValueArithmeticDriver.cs
+++ b/Components/Transform/Drivers/MultiValueArithmeticDriver.cs
@@ -1,70 +1,69 @@
 ﻿using System.Linq;
-using Elements.Assets;
 using Elements.Core;
 using FrooxEngine;
 
 namespace Obsidian;
 
+public enum ArithmeticMode
+{
+	Addition,
+	Subtraction,
+	Multiplication,
+	Division
+}
+
 [Category(new string[] { "Obsidian/Transform/Drivers" })]
 [GenericTypes(GenericTypesAttribute.Group.Primitives)]
 public class MultiValueArithmeticDriver<T> : Component
 {
-    public static bool IsValidGenericType => Coder<T>.SupportsAddSub;
+	public static bool IsValidGenericType => Coder<T>.SupportsAddSub;
 
-    public enum ArithmeticMode
-    {
-        Addition,
-        Subtraction,
-        Multiplication,
-        Division
-    }
+	public readonly FieldDrive<T> Target;
 
-    public readonly FieldDrive<T> Target;
+	public readonly Sync<ArithmeticMode> Mode;
 
-    public readonly Sync<ArithmeticMode> Mode;
+	public readonly SyncList<Sync<T>> Values;
 
-    public readonly SyncList<Sync<T>> Values;
-
-    protected override void OnChanges()
-    {
-        if (!Target.IsLinkValid || Values.Count == 0)
-        {
-            return;
-        }
-        if (Values.Contains(Target.Target))
-        {
-            // don't let the component drive itself, don't want a feedback loop
-            Target.ReleaseLink();
-            return;
-        }
-        T value = Values[0].Value;
-        switch (Mode.Value)
-        {
-            case ArithmeticMode.Addition:
-                foreach (Sync<T> sync in Values.Skip(1))
-                {
-                    value = Coder<T>.Add(value, sync.Value);
-                }
-                break;
-            case ArithmeticMode.Subtraction:
-                foreach (Sync<T> sync in Values.Skip(1))
-                {
-                    value = Coder<T>.Sub(value, sync.Value);
-                }
-                break;
-            case ArithmeticMode.Multiplication:
-                foreach (Sync<T> sync in Values.Skip(1))
-                {
-                    value = Coder<T>.Mul(value, sync.Value);
-                }
-                break;
-            case ArithmeticMode.Division:
-                foreach (Sync<T> sync in Values.Skip(1))
-                {
-                    value = Coder<T>.Div(value, sync.Value);
-                }
-                break;
-        }
-        Target.Target.Value = value;
-    }
+	protected override void OnChanges()
+	{
+		if (!Target.IsLinkValid || Values.Count == 0)
+		{
+			return;
+		}
+		if (Values.Contains(Target.Target))
+		{
+			// don't let the component drive itself, don't want a feedback loop
+			Target.ReleaseLink();
+			return;
+		}
+		T value = Values[0].Value;
+		switch (Mode.Value)
+		{
+			case ArithmeticMode.Addition:
+				foreach (Sync<T> sync in Values.Skip(1))
+				{
+					value = Coder<T>.Add(value, sync.Value);
+				}
+				break;
+			case ArithmeticMode.Subtraction:
+				foreach (Sync<T> sync in Values.Skip(1))
+				{
+					value = Coder<T>.Sub(value, sync.Value);
+				}
+				break;
+			case ArithmeticMode.Multiplication:
+				foreach (Sync<T> sync in Values.Skip(1))
+				{
+					value = Coder<T>.Mul(value, sync.Value);
+				}
+				break;
+			case ArithmeticMode.Division:
+				foreach (Sync<T> sync in Values.Skip(1))
+				{
+					value = Coder<T>.Div(value, sync.Value);
+				}
+				break;
+		}
+		Target.Target.Value = value;
+	}
 }

--- a/ProjectObsidian.csproj
+++ b/ProjectObsidian.csproj
@@ -12,6 +12,7 @@
     <ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
     <ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
     <ResonitePath Condition="Exists('/mnt/LocalDisk2/SteamLibrary/steamapps/common/Resonite/')">/mnt/LocalDisk2/SteamLibrary/steamapps/common/Resonite/</ResonitePath>
+	<ResonitePath Condition="Exists('G:\SteamLibrary\steamapps\common\Resonite\')">G:\SteamLibrary\steamapps\common\Resonite\</ResonitePath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="ProtoFlux\Bindings\Networking\**" />


### PR DESCRIPTION
Basically this just moves the enum outside of the generic class and into the Obsidian namespace

I also changed the file `MultiValueArithmeticDriver.cs` to use tabs instead of spaces because that's what I'm used to