### PR TITLE
Allow ComponentsDataFeed to enumerate the component library, add ButtonAttachComponent, cleanup stuff

### DIFF
--- a/ProjectObsidian/Components/Common UI/Button Interactions/ButtonAttachComponent.cs
+++ b/ProjectObsidian/Components/Common UI/Button Interactions/ButtonAttachComponent.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using FrooxEngine;
+using FrooxEngine.Undo;
+
+namespace Obsidian;
+
+[Category(new string[] { "Obsidian/Common UI/Button Interactions" })]
+public class ButtonAttachComponent : Component, IButtonPressReceiver, IComponent, IComponentBase, IDestroyable, IWorker, IWorldElement, IUpdatable, IChangeable, IAudioUpdatable, IInitializable, ILinkable
+{
+    public readonly SyncRef<Slot> TargetSlot;
+
+    public readonly SyncType ComponentType;
+
+    public readonly Sync<bool> Undoable;
+
+    protected override void OnAttach()
+    {
+        base.OnAwake();
+        Undoable.Value = true;
+    }
+
+    public void Pressed(IButton button, ButtonEventData eventData)
+    {
+        Slot target = TargetSlot.Target;
+        Type componentType = ComponentType.Value;
+        if (target != null && componentType != null && componentType.ContainsGenericParameters == false)
+        {
+            var comp = target.AttachComponent(componentType);
+            if (Undoable)
+            {
+                comp.CreateSpawnUndoPoint();
+            }
+        }
+    }
+
+    public void Pressing(IButton button, ButtonEventData eventData)
+    {
+    }
+
+    public void Released(IButton button, ButtonEventData eventData)
+    {
+    }
+}

--- a/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentData.cs
+++ b/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentData.cs
@@ -11,21 +11,37 @@ public class ComponentData
 
     public Component component;
 
+    private Type _componentType;
+
     public bool Submitted { get; private set; }
 
     public string MainName
     {
         get
         {
-            return component.Name;
+            return component?.Name ?? _componentType.Name;
         }
     }
 
+    public string uniqueId;
+
     public int MemberCount => members.Count;
+
+    public Type ComponentType => component?.GetType() ?? _componentType;
+
+    public bool IsGenericType => ComponentType.IsGenericType;
+
+    public Type GenericTypeDefinition => IsGenericType ? ComponentType.GetGenericTypeDefinition() : null;
 
     public ComponentData(Component component)
     {
         this.component = component;
+        _componentType = component.GetType();
+    }
+
+    public ComponentData(Type type)
+    {
+        this._componentType = type;
     }
 
     public void MarkSubmitted()
@@ -87,12 +103,9 @@ public class ComponentData
 
     public bool MatchesTerm(string term)
     {
-        if (component != null)
+        if (ContainsTerm(MainName, term))
         {
-            if (ContainsTerm(component.Name, term))
-            {
-                return true;
-            }
+            return true;
         }
         return false;
     }
@@ -108,6 +121,6 @@ public class ComponentData
 
     public override string ToString()
     {
-        return $"Name: {MainName}, ReferenceID: {component.ReferenceID}, Members: {members.Count}";
+        return $"Name: {MainName}, UniqueID: {uniqueId}, MemberCount: {MemberCount}";
     }
 }

--- a/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentDataFeedItem.cs
+++ b/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentDataFeedItem.cs
@@ -11,7 +11,7 @@ public class ComponentDataFeedItem : DataFeedItem
 
     public ComponentDataFeedItem(ComponentData componentData)
     {
-        InitBase(componentData.component.ReferenceID.ToString(), null, null, componentData.MainName);
+        InitBase(componentData.uniqueId, null, null, componentData.MainName);
         Data = componentData;
         foreach (ISyncMember member in componentData.members)
         {

--- a/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentsDataFeed.cs
+++ b/ProjectObsidian/Components/Radiant UI/Data Feeds/Feeds/ComponentsDataFeed.cs
@@ -205,16 +205,23 @@ public class ComponentsDataFeed : Component, IDataFeedComponent, IDataFeed, IWor
         }
     }
 
+    private DataFeedCategory GenerateCategory(string key, IReadOnlyList<string> path)
+    {
+        DataFeedCategory dataFeedCategory = new DataFeedCategory();
+        dataFeedCategory.InitBase(key, path, null, ("Category." + key).AsLocaleKey(), OfficialAssets.Graphics.Icons.Gizmo.TransformLocal);
+        return dataFeedCategory;
+    }
+
     public async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData)
     {
         if (TargetSlot.Target != null && (path != null && path.Count > 0))
         {
             yield break;
         }
-        if (TargetSlot.Target == null && (path == null || path.Count == 0) && !SearchStringValid(searchPhrase))
-        {
-            yield break;
-        }
+        //if (TargetSlot.Target == null && (path == null || path.Count == 0) && !SearchStringValid(searchPhrase))
+        //{
+        //    yield break;
+        //}
         if (groupKeys != null && groupKeys.Count > 0)
         {
             yield break;
@@ -242,6 +249,10 @@ public class ComponentsDataFeed : Component, IDataFeedComponent, IDataFeed, IWor
                         yield break;
                     }
                 }
+                foreach (var subCat2 in catNode.Subcategories)
+                {
+                    yield return GenerateCategory(subCat2.Name, path);
+                }
                 if (SearchStringValid(searchPhrase))
                 {
                     foreach (var elem in EnumerateAllTypes(catNode))
@@ -263,9 +274,16 @@ public class ComponentsDataFeed : Component, IDataFeedComponent, IDataFeed, IWor
                 {
                     GetAllTypes(_componentTypes, lib);
                 }
-                foreach (var elem in _componentTypes)
+                foreach (var subCat in lib.Subcategories)
                 {
-                    componentDataFeedData.AddComponentType(elem);
+                    yield return GenerateCategory(subCat.Name, path);
+                }
+                if (SearchStringValid(searchPhrase))
+                {
+                    foreach (var elem in _componentTypes)
+                    {
+                        componentDataFeedData.AddComponentType(elem);
+                    }
                 }
             }
         }

--- a/ProjectObsidian/Components/Radiant UI/Data Feeds/Interfaces/ComponentDataItemInterface.cs
+++ b/ProjectObsidian/Components/Radiant UI/Data Feeds/Interfaces/ComponentDataItemInterface.cs
@@ -1,4 +1,5 @@
-﻿using FrooxEngine;
+﻿using System;
+using FrooxEngine;
 
 namespace Obsidian;
 
@@ -6,6 +7,12 @@ namespace Obsidian;
 public class ComponentDataItemInterface : FeedItemInterface
 {
     public readonly SyncRef<SyncRef<Component>> Component;
+
+    public readonly SyncRef<IField<System.Type>> Type;
+
+    public readonly SyncRef<IField<bool>> IsGenericType;
+
+    public readonly SyncRef<IField<System.Type>> GenericTypeDefinition;
 
     public readonly SyncRef<IField<int>> MemberCount;
 
@@ -17,6 +24,9 @@ public class ComponentDataItemInterface : FeedItemInterface
         if (item is ComponentDataFeedItem componentDataFeedItem)
         {
             Component.TrySetTarget(componentDataFeedItem.Data.component);
+            Type.TrySetTarget(componentDataFeedItem.Data.ComponentType);
+            IsGenericType.TrySetTarget(componentDataFeedItem.Data.IsGenericType);
+            GenericTypeDefinition.TrySetTarget(componentDataFeedItem.Data.GenericTypeDefinition);
             MemberCount.TrySetTarget(componentDataFeedItem.Data.MemberCount);
             Members.Set(componentDataFeedItem.Members, view);
         }

--- a/ProjectObsidian/ProjectObsidian.csproj
+++ b/ProjectObsidian/ProjectObsidian.csproj
@@ -54,7 +54,10 @@
 	  <Reference Include="SteamVR">
 	    <HintPath>$(ResonitePath)/Resonite_Data/Managed/SteamVR.dll</HintPath>
 	  </Reference>
-	  <Reference Include="System.Net.Http" />  
+	  <Reference Include="System.Net.Http" />
+	  <Reference Include="System.ValueTuple">
+	    <HintPath>$(ResonitePath)/Resonite_Data/Managed/System.ValueTuple.dll</HintPath>
+	  </Reference>  
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProjectObsidian.SourceGenerators\SourceGenerators.csproj" OutputItemType="Analyzer" />


### PR DESCRIPTION
Feed can return categories and components from the component library, and can be searched using a searchPhrase on the feed view component.

Added ButtonAttachComponent, which attaches a Type of component to a target slot with a button press (UIX or physical button), supports undo

ComponentDataItemInterface has new data:

- Type <Type>

- IsGenericType <bool>

- GenericTypeDefinition <Type>