### PR TITLE
Eye tracking node fix

### DIFF
--- a/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
+++ b/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
@@ -25,6 +25,10 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Users.Status
                     {
                         return eyeTrackingStreamManager.GetIsTracking(side);
                     }
+                    else
+                    {
+                        return eyeTrackingStreamManager.GetIsTracking(EyeSide.Left) && eyeTrackingStreamManager.GetIsTracking(EyeSide.Right);
+                    }
                 }
             }
             return false;

--- a/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
+++ b/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
@@ -1,6 +1,5 @@
 ﻿using FrooxEngine;
 using FrooxEngine.ProtoFlux;
-using FrooxEngine.ProtoFlux.Runtimes.Execution.Nodes;
 using ProtoFlux.Core;
 using ProtoFlux.Runtimes.Execution;
 
@@ -11,7 +10,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Users.Status
     public class IsUserEyeTracking : ValueFunctionNode<FrooxEngineContext, bool>
     {
         public readonly ObjectInput<User> User;
-        public readonly ObjectInput<EyeSide> Side;
+        public readonly ValueInput<EyeSide> Side;
 
         protected override bool Compute(FrooxEngineContext context)
         {

--- a/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
+++ b/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
@@ -22,7 +22,10 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Users.Status
                 if (eyeTrackingStreamManager != null)
                 {
                     EyeSide side = Side.Evaluate(context);
-                    return eyeTrackingStreamManager.GetIsTracking(side);
+                    if (side != EyeSide.Combined)
+                    {
+                        return eyeTrackingStreamManager.GetIsTracking(side);
+                    }
                 }
             }
             return false;


### PR DESCRIPTION
Fixes a crash when the EyeSide is combined

Fixes EyeSide enum not connecting due to wrong Input type