### PR TITLE
Add plugin settings to toggle loading the plugin when starting new sessions

### DIFF
--- a/ProjectObsidian/Injection/Injection.cs
+++ b/ProjectObsidian/Injection/Injection.cs
@@ -5,7 +5,6 @@ using Elements.Core;
 using FrooxEngine;
 using FrooxEngine.ProtoFlux.Core;
 using Obsidian.Shaders;
-using System.Collections.Generic;
 
 namespace Obsidian
 {
@@ -16,9 +15,6 @@ namespace Obsidian
         private static Type? __connectorType;
         private static Type? __connectorTypes;
 
-        private static AssemblyTypeRegistry obsidianRegistry;
-        private static bool registered = true;
-
         // Static constructor for initializing the hook
         static ExecutionHook()
         {
@@ -27,28 +23,7 @@ namespace Obsidian
                 Engine.Current.OnReady += () =>
                 {
                     ShaderInjection.AppendShaders();
-                    DevCreateNewForm.AddAction("Plugins", "Register/Unregister Obsidian Assembly", (Slot s) => 
-                    { 
-                        s.Destroy();
-                        var glob = (List<AssemblyTypeRegistry>)typeof(GlobalTypeRegistry).GetField("_coreAssemblies", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
-                        if (registered)
-                        {
-                            foreach (var thing in glob.ToList())
-                            {
-                                if (thing.Assembly == Assembly.GetExecutingAssembly())
-                                {
-                                    obsidianRegistry = thing;
-                                    glob.Remove(thing);
-                                }
-                            }
-                            registered = false;
-                        }
-                        else
-                        {
-                            glob.Add(obsidianRegistry);
-                            registered = true;
-                        }
-                    });
+                    Settings.GetActiveSetting<PluginSettings>();
                 };
             }
             catch (Exception e)

--- a/ProjectObsidian/Injection/Injection.cs
+++ b/ProjectObsidian/Injection/Injection.cs
@@ -5,6 +5,7 @@ using Elements.Core;
 using FrooxEngine;
 using FrooxEngine.ProtoFlux.Core;
 using Obsidian.Shaders;
+using System.Collections.Generic;
 
 namespace Obsidian
 {
@@ -15,6 +16,9 @@ namespace Obsidian
         private static Type? __connectorType;
         private static Type? __connectorTypes;
 
+        private static AssemblyTypeRegistry obsidianRegistry;
+        private static bool registered = true;
+
         // Static constructor for initializing the hook
         static ExecutionHook()
         {
@@ -22,8 +26,29 @@ namespace Obsidian
             {
                 Engine.Current.OnReady += () =>
                 {
-                   ShaderInjection.AppendShaders();
-                    
+                    ShaderInjection.AppendShaders();
+                    DevCreateNewForm.AddAction("Plugins", "Register/Unregister Obsidian Assembly", (Slot s) => 
+                    { 
+                        s.Destroy();
+                        var glob = (List<AssemblyTypeRegistry>)typeof(GlobalTypeRegistry).GetField("_coreAssemblies", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+                        if (registered)
+                        {
+                            foreach (var thing in glob.ToList())
+                            {
+                                if (thing.Assembly == Assembly.GetExecutingAssembly())
+                                {
+                                    obsidianRegistry = thing;
+                                    glob.Remove(thing);
+                                }
+                            }
+                            registered = false;
+                        }
+                        else
+                        {
+                            glob.Add(obsidianRegistry);
+                            registered = true;
+                        }
+                    });
                 };
             }
             catch (Exception e)

--- a/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
+++ b/ProjectObsidian/ProtoFlux/Users/Status/IsUserEyeTracking.cs
@@ -25,6 +25,10 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Users.Status
                     {
                         return eyeTrackingStreamManager.GetIsTracking(side);
                     }
+                    else
+                    {
+                        return eyeTrackingStreamManager.GetIsTracking(EyeSide.Left) && eyeTrackingStreamManager.GetIsTracking(EyeSide.Right);
+                    }
                 }
             }
             return false;

--- a/ProjectObsidian/Settings/MIDI_Settings.cs
+++ b/ProjectObsidian/Settings/MIDI_Settings.cs
@@ -88,7 +88,6 @@ public class MIDI_Settings : SettingComponent<MIDI_Settings>
         _localeData.LocaleCode = "en";
         _localeData.Authors = new List<string>() { "Nytra" };
         _localeData.Messages = new Dictionary<string, string>();
-        _localeData.Messages.Add("Settings.Category.Obsidian", "Obsidian");
         _localeData.Messages.Add("Settings.MIDI_Settings", "MIDI Settings");
         _localeData.Messages.Add("Settings.MIDI_Settings.RefreshDeviceLists", "Refresh Devices");
         _localeData.Messages.Add("Settings.MIDI_Settings.InputDevices", "Input Devices");

--- a/ProjectObsidian/Settings/PluginSettings.cs
+++ b/ProjectObsidian/Settings/PluginSettings.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using FrooxEngine;
+using Elements.Core;
+using Elements.Assets;
+using Commons.Music.Midi;
+using System.Reflection;
+
+namespace Obsidian;
+
+[SettingCategory("Obsidian")]
+public class PluginSettings : SettingComponent<PluginSettings>
+{
+    public override bool UserspaceOnly => true;
+
+    [NonPersistent]
+    [SettingIndicatorProperty(null, null, null, null, false, 0L)]
+    public readonly Sync<bool> CoreAssemblyLoaded;
+
+    private LocaleData _localeData;
+
+    private static AssemblyTypeRegistry obsidianRegistry;
+
+    protected override void OnStart()
+    {
+        base.OnStart();
+        _localeData = new LocaleData();
+        _localeData.LocaleCode = "en";
+        _localeData.Authors = new List<string>() { "Nytra" };
+        _localeData.Messages = new Dictionary<string, string>();
+        _localeData.Messages.Add("Settings.Category.Obsidian", "Obsidian");
+        _localeData.Messages.Add("Settings.PluginSettings", "Plugin Settings");
+        _localeData.Messages.Add("Settings.PluginSettings.CoreAssemblyLoaded", "Core Assembly Loaded");
+        _localeData.Messages.Add("Settings.PluginSettings.ToggleCoreAssembly", "Toggle Core Assembly");
+
+        CoreAssemblyLoaded.Value = true;
+
+        // Sometimes the locale is null in here, so wait a bit I guess
+
+        RunInUpdates(15, () =>
+        {
+            UpdateLocale();
+            Settings.RegisterValueChanges<LocaleSettings>(UpdateLocale);
+        });
+    }
+
+    protected override void OnDispose()
+    {
+        base.OnDispose();
+        Settings.UnregisterValueChanges<LocaleSettings>(UpdateLocale);
+    }
+
+    private void UpdateLocale(LocaleSettings settings = null)
+    {
+        this.GetCoreLocale()?.Asset?.Data.LoadDataAdditively(_localeData);
+    }
+
+    [SettingProperty(null, null, null, false, 0L, null, null)]
+    [SyncMethod(typeof(Action), new string[] { })]
+    public void ToggleCoreAssembly()
+    {
+        UniLog.Log("Toggle pressed");
+        var glob = (List<AssemblyTypeRegistry>)typeof(GlobalTypeRegistry).GetField("_coreAssemblies", BindingFlags.NonPublic | BindingFlags.Static).GetValue(null);
+        if (CoreAssemblyLoaded)
+        {
+            foreach (var thing in glob.ToList())
+            {
+                if (thing.Assembly == Assembly.GetExecutingAssembly())
+                {
+                    obsidianRegistry = thing;
+                    glob.Remove(thing);
+                }
+            }
+            CoreAssemblyLoaded.Value = false;
+        }
+        else
+        {
+            glob.Add(obsidianRegistry);
+            CoreAssemblyLoaded.Value = true;
+        }
+    }
+}


### PR DESCRIPTION
Adds Plugin Settings to the dash to toggle Obsidian as a core assembly, which allows controlling if it gets loaded when starting sessions

![Screenshot 2024-11-28 045733](https://github.com/user-attachments/assets/393bad70-03d8-49e8-8ce5-1199bc3bac13)