### PR TITLE
Clamp audio buffer values to prevent audio breaking, Use IsActive, update filters to handle different types, use audio update callback

### DIFF
--- a/ProjectObsidian/Components/Audio/BandPassFilter.cs
+++ b/ProjectObsidian/Components/Audio/BandPassFilter.cs
@@ -42,6 +42,7 @@ namespace Obsidian.Components.Audio
 
             Span<S> tempBuffer = stackalloc S[buffer.Length];
             tempBuffer = buffer;
+
             Source.Target.Read(tempBuffer);
 
             if (lowFilter == null)

--- a/ProjectObsidian/Components/Audio/BandPassFilter.cs
+++ b/ProjectObsidian/Components/Audio/BandPassFilter.cs
@@ -3,6 +3,7 @@ using FrooxEngine;
 using Elements.Assets;
 using System.Net;
 using ProtoFlux.Runtimes.Execution;
+using System.Collections.Generic;
 
 namespace Obsidian.Components.Audio
 {
@@ -22,8 +23,8 @@ namespace Obsidian.Components.Audio
 
         private double lastTime;
 
-        private object lowFilter = null;
-        private object highFilter = null;
+        private Dictionary<Type, object> lowFilters = new();
+        private Dictionary<Type, object> highFilters = new();
 
         public bool IsActive
         {
@@ -37,6 +38,8 @@ namespace Obsidian.Components.Audio
             if (!IsActive)
             {
                 buffer.Fill(default(S));
+                lowFilters.Clear();
+                highFilters.Clear();
                 return;
             }
 
@@ -45,17 +48,19 @@ namespace Obsidian.Components.Audio
 
             Source.Target.Read(tempBuffer);
 
-            if (lowFilter == null)
+            if (!lowFilters.TryGetValue(typeof(S), out object lowFilter))
             {
                 lowFilter = new ButterworthFilter.FilterButterworth<S>();
+                lowFilters.Add(typeof(S), lowFilter);
             }
-            if (highFilter == null)
+            if (!highFilters.TryGetValue(typeof(S), out object highFilter))
             {
                 highFilter = new ButterworthFilter.FilterButterworth<S>();
+                highFilters.Add(typeof(S), highFilter);
             }
 
-            ((ButterworthFilter.FilterButterworth<S>)lowFilter).UpdateCoefficients(HighFrequency, (int)(tempBuffer.Length / (Engine.Current.AudioSystem.DSPTime - lastTime)), ButterworthFilter.FilterButterworth<S>.PassType.Lowpass, Resonance);
-            ((ButterworthFilter.FilterButterworth<S>)highFilter).UpdateCoefficients(LowFrequency, (int)(tempBuffer.Length / (Engine.Current.AudioSystem.DSPTime - lastTime)), ButterworthFilter.FilterButterworth<S>.PassType.Highpass, Resonance);
+            ((ButterworthFilter.FilterButterworth<S>)lowFilter).UpdateCoefficients(HighFrequency, Engine.AudioSystem.SampleRate, ButterworthFilter.FilterButterworth<S>.PassType.Lowpass, Resonance);
+            ((ButterworthFilter.FilterButterworth<S>)highFilter).UpdateCoefficients(LowFrequency, Engine.AudioSystem.SampleRate, ButterworthFilter.FilterButterworth<S>.PassType.Highpass, Resonance);
 
             for (int i = 0; i < tempBuffer.Length; i++)
             {
@@ -80,8 +85,8 @@ namespace Obsidian.Components.Audio
             base.OnChanges();
             if (Source.GetWasChangedAndClear())
             {
-                lowFilter = null;
-                highFilter = null;
+                lowFilters.Clear();
+                highFilters.Clear();
             }
         }
     }

--- a/ProjectObsidian/Components/Audio/ButterworthFilter.cs
+++ b/ProjectObsidian/Components/Audio/ButterworthFilter.cs
@@ -138,6 +138,12 @@ public class ButterworthFilter : Component, IAudioSource, IWorldElement
             S fifth = this.outputHistory[1].Multiply(b2);
             S final = first.Add(second).Add(third).Subtract(fourth).Subtract(fifth);
 
+            for (int i = 0; i < final.ChannelCount; i++)
+            {
+                if (final[i] > 1) final = final.SetChannel(i, 1f);
+                if (final[i] < -1) final = final.SetChannel(i, -1f);
+            }
+
             this.inputHistory[1] = this.inputHistory[0];
             this.inputHistory[0] = newInput;
 

--- a/ProjectObsidian/Components/Audio/FrequencyModulator.cs
+++ b/ProjectObsidian/Components/Audio/FrequencyModulator.cs
@@ -66,15 +66,18 @@ namespace Obsidian.Components.Audio
             // Apply FM synthesis
             for (int i = 0; i < buffer.Length; i++)
             {
-                // Get carrier and modulator values
-                float carrierValue = carrierBuffer[i].AbsoluteAmplitude;
-                float modulatorValue = modulatorBuffer[i].AbsoluteAmplitude;
+                for (int j = 0; j < buffer[i].ChannelCount; j++)
+                {
+                    float carrierValue = carrierBuffer[i][j];
+                    float modulatorValue = modulatorBuffer[i][j];
 
-                // Compute frequency modulation
-                float modulatedValue = (float)(carrierValue * Math.Sin(2 * Math.PI * modulationIndex * modulatorValue));
+                    float modulatedValue = (float)(carrierValue * Math.Sin(2 * Math.PI * modulationIndex * modulatorValue));
 
-                // Write modulated value to the buffer
-                buffer[i] = buffer[i].Bias(buffer[i].AbsoluteAmplitude - modulatedValue);
+                    buffer[i] = buffer[i].SetChannel(j, modulatedValue);
+
+                    if (buffer[i][j] > 1f) buffer[i] = buffer[i].SetChannel(j, 1f);
+                    if (buffer[i][j] < -1f) buffer[i] = buffer[i].SetChannel(j, -1f);
+                }
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
@@ -43,6 +43,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             for (int i = 0; i < buffer.Length; i++)
             {
                 newBuffer[i] = newBuffer[i].Add(newBuffer2[i]);
+
+                for (int j = 0; j < newBuffer[i].ChannelCount; j++)
+                {
+                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
+                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                }
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
@@ -21,6 +21,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         public void Read<S>(Span<S> buffer) where S : unmanaged, IAudioSample<S>
         {
+            if (!IsActive)
+            {
+                buffer.Fill(default(S));
+                return;
+            }
+
             Span<S> newBuffer = stackalloc S[buffer.Length];
             newBuffer = buffer;
             Span<S> newBuffer2 = stackalloc S[buffer.Length];
@@ -47,7 +53,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 for (int j = 0; j < newBuffer[i].ChannelCount; j++)
                 {
                     if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
-                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                    else if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
                 }
             }
         }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
@@ -22,6 +22,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         public void Read<S>(Span<S> buffer) where S : unmanaged, IAudioSample<S>
         {
+            if (!IsActive)
+            {
+                buffer.Fill(default(S));
+                return;
+            }
+
             Span<S> newBuffer = stackalloc S[buffer.Length];
             newBuffer = buffer;
             if (AudioInput != null)

--- a/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
@@ -35,6 +35,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             for (int i = 0; i < buffer.Length; i++)
             {
                 newBuffer[i] = newBuffer[i].Multiply(Value);
+
+                for (int j = 0; j < newBuffer[i].ChannelCount; j++)
+                {
+                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
+                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                }
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
@@ -43,6 +43,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             for (int i = 0; i < buffer.Length; i++)
             {
                 newBuffer[i] = newBuffer[i].Subtract(newBuffer2[i]);
+
+                for (int j = 0; j < newBuffer[i].ChannelCount; j++)
+                {
+                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
+                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                }
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
@@ -21,6 +21,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         public void Read<S>(Span<S> buffer) where S : unmanaged, IAudioSample<S>
         {
+            if (!IsActive)
+            {
+                buffer.Fill(default(S));
+                return;
+            }
+
             Span<S> newBuffer = stackalloc S[buffer.Length];
             newBuffer = buffer;
             Span<S> newBuffer2 = stackalloc S[buffer.Length];
@@ -47,7 +53,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 for (int j = 0; j < newBuffer[i].ChannelCount; j++)
                 {
                     if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
-                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                    else if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
                 }
             }
         }


### PR DESCRIPTION
Fixes #69 
Fixes https://github.com/Xlinka/Project-Obsidian/issues/70