### PR TITLE
A lot of stuff

### DIFF
--- a/ProjectObsidian/Components/Audio/EMA_IIR_SmoothSignal.cs
+++ b/ProjectObsidian/Components/Audio/EMA_IIR_SmoothSignal.cs
@@ -5,7 +5,7 @@ using Obsidian.Elements;
 
 namespace Obsidian.Components.Audio;
 
-[Category(new string[] { "Obsidian/Audio/Effects" })]
+[Category(new string[] { "Obsidian/Audio/Filters" })]
 public class EMA_IIR_SmoothSignal : Component, IAudioSource, IWorldElement
 {
     [Range(0f, 1f, "0.00")]

--- a/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioAdder.cs
@@ -27,16 +27,14 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             Span<S> newBuffer2 = stackalloc S[buffer.Length];
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
             if (AudioInput2 != null)
             {
@@ -48,7 +46,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             }
             for (int i = 0; i < buffer.Length; i++)
             {
-                newBuffer[i] = newBuffer[i].Add(newBuffer2[i]);
+                buffer[i] = buffer[i].Add(newBuffer2[i]);
 
                 //for (int j = 0; j < ChannelCount; j++)
                 //{

--- a/ProjectObsidian/ProtoFlux/Audio/AudioClamp.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioClamp.cs
@@ -30,16 +30,14 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
-            AudioInput.Read(newBuffer);
+            AudioInput.Read(buffer);
 
             for (int i = 0; i < buffer.Length; i++)
             {
                 for (int j = 0; j < ChannelCount; j++)
                 {
-                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
-                    else if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                    if (buffer[i][j] > 1f) buffer[i] = buffer[i].SetChannel(j, 1f);
+                    else if (buffer[i][j] < -1f) buffer[i] = buffer[i].SetChannel(j, -1f);
                 }
             }
         }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
@@ -27,19 +27,17 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
             for (int i = 0; i < buffer.Length; i++)
             {
-                newBuffer[i] = newBuffer[i].Multiply(Value);
+                buffer[i] = buffer[i].Multiply(Value);
 
                 //for (int j = 0; j < ChannelCount; j++)
                 //{

--- a/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioMultiply.cs
@@ -41,11 +41,11 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             {
                 newBuffer[i] = newBuffer[i].Multiply(Value);
 
-                for (int j = 0; j < ChannelCount; j++)
-                {
-                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
-                    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
-                }
+                //for (int j = 0; j < ChannelCount; j++)
+                //{
+                //    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
+                //    if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                //}
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
@@ -27,16 +27,14 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             Span<S> newBuffer2 = stackalloc S[buffer.Length];
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
             if (AudioInput2 != null)
             {
@@ -48,7 +46,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             }
             for (int i = 0; i < buffer.Length; i++)
             {
-                newBuffer[i] = newBuffer[i].Subtract(newBuffer2[i]);
+                buffer[i] = buffer[i].Subtract(newBuffer2[i]);
 
                 //for (int j = 0; j < ChannelCount; j++)
                 //{

--- a/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/AudioSubtractor.cs
@@ -50,11 +50,11 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             {
                 newBuffer[i] = newBuffer[i].Subtract(newBuffer2[i]);
 
-                for (int j = 0; j < ChannelCount; j++)
-                {
-                    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
-                    else if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
-                }
+                //for (int j = 0; j < ChannelCount; j++)
+                //{
+                //    if (newBuffer[i][j] > 1f) newBuffer[i] = newBuffer[i].SetChannel(j, 1f);
+                //    else if (newBuffer[i][j] < -1f) newBuffer[i] = newBuffer[i].SetChannel(j, -1f);
+                //}
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
@@ -34,18 +34,16 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
 
-            _controller.Process(newBuffer, LowFrequency, HighFrequency, Resonance);
+            _controller.Process(buffer, LowFrequency, HighFrequency, Resonance);
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
@@ -34,18 +34,16 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
 
-            _controller.Process(newBuffer, LowPass, Frequency, Resonance);
+            _controller.Process(buffer, LowPass, Frequency, Resonance);
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/ChannelSplitter.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/ChannelSplitter.cs
@@ -33,19 +33,19 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
+            //Span<S> newBuffer = stackalloc S[buffer.Length];
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
 
             for (int i = 0; i < buffer.Length; i++)
             {
-                buffer[i] = buffer[i].SetChannel(0, newBuffer[i][Channel]);
+                buffer[i] = buffer[i].SetChannel(0, buffer[i][Channel]);
             }
         }
     }

--- a/ProjectObsidian/ProtoFlux/Audio/Delay.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/Delay.cs
@@ -41,9 +41,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
-            AudioInput.Read(newBuffer);
+            AudioInput.Read(buffer);
 
             if (!delays.TryGetValue(typeof(S), out var delay))
             {
@@ -52,7 +50,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 UniLog.Log("Created new delay");
             }
 
-            ((SimpleDelayEffect<S>)delay).Process(newBuffer, DryWet, feedback, update);
+            ((SimpleDelayEffect<S>)delay).Process(buffer, DryWet, feedback, update);
 
             if (update)
             {

--- a/ProjectObsidian/ProtoFlux/Audio/EMA_IIR_SmoothSignalNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/EMA_IIR_SmoothSignalNode.cs
@@ -28,18 +28,16 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
             if (AudioInput != null)
             {
-                AudioInput.Read(newBuffer);
+                AudioInput.Read(buffer);
             }
             else
             {
-                newBuffer.Fill(default);
+                buffer.Fill(default);
             }
 
-            Algorithms.EMAIIRSmoothSignal(ref newBuffer, newBuffer.Length, SmoothingFactor);
+            Algorithms.EMAIIRSmoothSignal(ref buffer, buffer.Length, SmoothingFactor);
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
@@ -58,9 +58,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 return;
             }
 
-            Span<S> newBuffer = stackalloc S[buffer.Length];
-            newBuffer = buffer;
-            AudioInput.Read(newBuffer);
+            AudioInput.Read(buffer);
 
             if (!filters.TryGetValue(typeof(S), out var filter))
             {
@@ -69,7 +67,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 UniLog.Log("Created new FIR filter");
             }
 
-            ((FirFilter<S>)filter).ProcessBuffer(newBuffer, update);
+            ((FirFilter<S>)filter).ProcessBuffer(buffer, update);
 
             if (update)
             {


### PR DESCRIPTION
- Added Delay node for audio
- Added AudioClamp node for audio
- Removed implicit clamping from audio adder, subtractor, multiply, and filters
- Fixed AudioAdder node not working when the first input is null
- Fixed FIR filter crackling when connected to more than one speaker
- Made FIR filter coefficients editable via the inspector (previously you could only view them)
- Recategorized some audio nodes and components
- Skip zero, infinity and NaN coefficients in FIR filter
- Optimized Delay and FIR filter to used cached buffers to avoid unnecessary processing costs when connected to multiple speakers
- Removed unnecessary stack allocations