### PR TITLE
Prevent double plugin toggle

### DIFF
--- a/ProjectObsidian/Settings/PluginSettings.cs
+++ b/ProjectObsidian/Settings/PluginSettings.cs
@@ -37,7 +37,12 @@ public class PluginSettings : SettingComponent<PluginSettings>
         _localeData.Messages.Add("Settings.PluginSettings.PluginLoaded", "Plugin Loaded");
         _localeData.Messages.Add("Settings.PluginSettings.TogglePluginLoaded", "Toggle loading the plugin for new sessions");
 
-        if (PluginLoaded.Value == false && GetObsidianRegistry() is AssemblyTypeRegistry obsidianRegistry && coreAssemblies.Contains(obsidianRegistry))
+        var obsidianRegistry = GetObsidianRegistry();
+        if (PluginLoaded.Value == false && obsidianRegistry != null && coreAssemblies.Contains(obsidianRegistry))
+        {
+            TogglePluginLoaded();
+        }
+        else if (PluginLoaded.Value == true && obsidianRegistry != null && !coreAssemblies.Contains(obsidianRegistry))
         {
             TogglePluginLoaded();
         }

--- a/ProjectObsidian/Settings/PluginSettings.cs
+++ b/ProjectObsidian/Settings/PluginSettings.cs
@@ -37,7 +37,7 @@ public class PluginSettings : SettingComponent<PluginSettings>
         _localeData.Messages.Add("Settings.PluginSettings.PluginLoaded", "Plugin Loaded");
         _localeData.Messages.Add("Settings.PluginSettings.TogglePluginLoaded", "Toggle loading the plugin for new sessions");
 
-        if (PluginLoaded.Value == false)
+        if (PluginLoaded.Value == false && GetObsidianRegistry() is AssemblyTypeRegistry obsidianRegistry && coreAssemblies.Contains(obsidianRegistry))
         {
             TogglePluginLoaded();
         }
@@ -96,11 +96,13 @@ public class PluginSettings : SettingComponent<PluginSettings>
         {
             if (coreAssemblies.Contains(obsidianRegistry))
             {
+                UniLog.Log("Removing Obsidian registry");
                 coreAssemblies.Remove(obsidianRegistry);
                 PluginLoaded.Value = false;
             }
             else if (!coreAssemblies.Contains(obsidianRegistry))
             {
+                UniLog.Log("Adding Obsidian registry");
                 coreAssemblies.Add(obsidianRegistry);
                 PluginLoaded.Value = true;
             }


### PR DESCRIPTION
This prevents the plugin being unloaded and then loaded again if the local settings and cloud settings both have the plugin disabled