### PR TITLE
Locale and settings improvements

### DIFF
--- a/ProjectObsidian/Injection/Injection.cs
+++ b/ProjectObsidian/Injection/Injection.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Linq;
-using System.Reflection;
+using System.Collections.Generic;
+using Elements.Assets;
 using Elements.Core;
 using FrooxEngine;
-using FrooxEngine.ProtoFlux.Core;
 using Obsidian.Shaders;
 
 namespace Obsidian
@@ -24,6 +23,30 @@ namespace Obsidian
                 {
                     ShaderInjection.AppendShaders();
                     Settings.GetActiveSetting<PluginSettings>();
+
+                    var _localeData = new LocaleData();
+                    _localeData.LocaleCode = "en";
+                    _localeData.Authors = new List<string>() { "Nytra" };
+                    _localeData.Messages = new Dictionary<string, string>();
+                    _localeData.Messages.Add("Settings.Category.Obsidian", "Obsidian");
+                    _localeData.Messages.Add("Settings.PluginSettings", "Plugin Settings");
+                    _localeData.Messages.Add("Settings.PluginSettings.PluginLoaded", "Plugin Loaded");
+                    _localeData.Messages.Add("Settings.PluginSettings.TogglePluginLoaded", "Toggle loading the plugin for new sessions");
+
+                    _localeData.Messages.Add("Settings.MIDI_Settings", "MIDI Settings");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.RefreshDeviceLists", "Refresh Devices");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.InputDevices", "Input Devices");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.OutputDevices", "Output Devices");
+
+                    _localeData.Messages.Add("Settings.MIDI_Settings.DeviceName", "Device Name");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.OutputDevices.Breadcrumb", "MIDI Output Devices");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.InputDevices.Breadcrumb", "MIDI Input Devices");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.AllowConnections", "Allow Connections");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.DeviceFound", "Device Found");
+                    _localeData.Messages.Add("Settings.MIDI_Settings.Remove", "Remove");
+
+                    SettingsLocaleHelper.RegisterData(_localeData);
+                    
                 };
             }
             catch (Exception e)

--- a/ProjectObsidian/Settings/LocaleHelper.cs
+++ b/ProjectObsidian/Settings/LocaleHelper.cs
@@ -1,0 +1,25 @@
+﻿using System.Threading.Tasks;
+using Elements.Assets;
+using FrooxEngine;
+
+namespace Obsidian;
+
+public static class SettingsLocaleHelper
+{
+    public static void RegisterData(LocaleData _localeData)
+    {
+        Task.Run(async () => 
+        {
+            while (Userspace.UserspaceWorld?.GetCoreLocale()?.Asset?.Data is null)
+            {
+                await default(NextUpdate);
+            }
+            UpdateLocale(_localeData);
+            Settings.RegisterValueChanges<LocaleSettings>(localeSettings => UpdateLocale(_localeData));
+        });
+    }
+    private static void UpdateLocale(LocaleData _localeData, LocaleSettings settings = null)
+    {
+        Userspace.UserspaceWorld?.GetCoreLocale()?.Asset?.Data?.LoadDataAdditively(_localeData);
+    }
+}

--- a/ProjectObsidian/Settings/MIDI_Settings.cs
+++ b/ProjectObsidian/Settings/MIDI_Settings.cs
@@ -49,8 +49,6 @@ public class MIDI_Settings : SettingComponent<MIDI_Settings>
     [SettingSubcategoryList("DeviceToItem", null, null, null, null, null)]
     public readonly SyncList<MIDI_Device> OutputDevices;
 
-    private LocaleData _localeData;
-
     private DataFeedItem DeviceToItem(ISyncMember item)
     {
         MIDI_Device device = (MIDI_Device)item;
@@ -85,43 +83,6 @@ public class MIDI_Settings : SettingComponent<MIDI_Settings>
     protected override void OnStart()
     {
         base.OnStart();
-        _localeData = new LocaleData();
-        _localeData.LocaleCode = "en";
-        _localeData.Authors = new List<string>() { "Nytra" };
-        _localeData.Messages = new Dictionary<string, string>();
-        _localeData.Messages.Add("Settings.MIDI_Settings", "MIDI Settings");
-        _localeData.Messages.Add("Settings.MIDI_Settings.RefreshDeviceLists", "Refresh Devices");
-        _localeData.Messages.Add("Settings.MIDI_Settings.InputDevices", "Input Devices");
-        _localeData.Messages.Add("Settings.MIDI_Settings.OutputDevices", "Output Devices");
-
-        _localeData.Messages.Add("Settings.MIDI_Settings.DeviceName", "Device Name");
-        _localeData.Messages.Add("Settings.MIDI_Settings.OutputDevices.Breadcrumb", "MIDI Output Devices");
-        _localeData.Messages.Add("Settings.MIDI_Settings.InputDevices.Breadcrumb", "MIDI Input Devices");
-        _localeData.Messages.Add("Settings.MIDI_Settings.AllowConnections", "Allow Connections");
-        _localeData.Messages.Add("Settings.MIDI_Settings.DeviceFound", "Device Found");
-        _localeData.Messages.Add("Settings.MIDI_Settings.Remove", "Remove");
-
-        Task.Run(async () =>
-        {
-            while (this.GetCoreLocale()?.Asset?.Data is null)
-            {
-                await default(NextUpdate);
-            }
-            UpdateLocale();
-            Settings.RegisterValueChanges<LocaleSettings>(UpdateLocale);
-            RefreshDeviceLists();
-        });
-    }
-
-    protected override void OnDispose()
-    {
-        base.OnDispose();
-        Settings.UnregisterValueChanges<LocaleSettings>(UpdateLocale);
-    }
-
-    private void UpdateLocale(LocaleSettings settings = null)
-    {
-        this.GetCoreLocale()?.Asset?.Data?.LoadDataAdditively(_localeData);
     }
 
     [SettingProperty(null, null, null, false, 0L, null, null)]

--- a/ProjectObsidian/Settings/PluginSettings.cs
+++ b/ProjectObsidian/Settings/PluginSettings.cs
@@ -18,25 +18,12 @@ public class PluginSettings : SettingComponent<PluginSettings>
     [SettingIndicatorProperty(null, null, null, null, false, 0L)]
     public readonly Sync<bool> PluginLoaded;
 
-    private LocaleData _localeData;
-
     private static AssemblyTypeRegistry obsidianRegistry;
 
     private static List<AssemblyTypeRegistry> coreAssemblies;
 
     protected override void OnStart()
     {
-        base.OnStart();
-
-        _localeData = new LocaleData();
-        _localeData.LocaleCode = "en";
-        _localeData.Authors = new List<string>() { "Nytra" };
-        _localeData.Messages = new Dictionary<string, string>();
-        _localeData.Messages.Add("Settings.Category.Obsidian", "Obsidian");
-        _localeData.Messages.Add("Settings.PluginSettings", "Plugin Settings");
-        _localeData.Messages.Add("Settings.PluginSettings.PluginLoaded", "Plugin Loaded");
-        _localeData.Messages.Add("Settings.PluginSettings.TogglePluginLoaded", "Toggle loading the plugin for new sessions");
-
         var obsidianRegistry = GetObsidianRegistry();
         if (PluginLoaded.Value == false && obsidianRegistry != null && coreAssemblies.Contains(obsidianRegistry))
         {
@@ -46,27 +33,6 @@ public class PluginSettings : SettingComponent<PluginSettings>
         {
             TogglePluginLoaded();
         }
-
-        Task.Run(async () => 
-        { 
-            while (this.GetCoreLocale()?.Asset?.Data is null)
-            {
-                await default(NextUpdate);
-            }
-            UpdateLocale();
-            Settings.RegisterValueChanges<LocaleSettings>(UpdateLocale);
-        });
-    }
-
-    protected override void OnDispose()
-    {
-        base.OnDispose();
-        Settings.UnregisterValueChanges<LocaleSettings>(UpdateLocale);
-    }
-
-    private void UpdateLocale(LocaleSettings settings = null)
-    {
-        this.GetCoreLocale()?.Asset?.Data?.LoadDataAdditively(_localeData);
     }
 
     private AssemblyTypeRegistry GetObsidianRegistry()
@@ -110,6 +76,16 @@ public class PluginSettings : SettingComponent<PluginSettings>
                 UniLog.Log("Adding Obsidian registry");
                 coreAssemblies.Add(obsidianRegistry);
                 PluginLoaded.Value = true;
+            }
+            try
+            {
+                var localSettings = Userspace.UserspaceWorld.GetGloballyRegisteredComponent<SettingManagersManager>().LocalSettings.Target;
+                var localPluginSettings = localSettings.GetSetting<PluginSettings>();
+                localPluginSettings.PluginLoaded.Value = PluginLoaded.Value;
+            }
+            catch (Exception ex)
+            {
+                UniLog.Error($"Could not update local plugin settings! {ex}");
             }
         }
     }


### PR DESCRIPTION
Fixes an edge case where the plugin would be unloaded and then loaded again if both the local plugin settings and cloud plugin settings have the plugin disabled

This also fixes locale not loading on first launch of Obsidian (Adds SettingsLocaleHelper and moves locale loading to Injection.cs)

This also syncs local plugin settings with cloud plugin settings when you toggle the plugin on or off