### PR TITLE
Use thread locks and account for buffer resizing

### DIFF
--- a/ProjectObsidian/Elements/Audio.cs
+++ b/ProjectObsidian/Elements/Audio.cs
@@ -249,8 +249,16 @@ public class FirFilter<S> : IFirFilter where S : unmanaged, IAudioSample<S>
     {
         if (!update && lastBuffer != null)
         {
-            lastBuffer.CopyTo(inputBuffer);
-            return;
+            // check if buffer size changed
+            if (lastBuffer.Length != inputBuffer.Length)
+            {
+                lastBuffer = null;
+            }
+            else
+            {
+                lastBuffer.CopyTo(inputBuffer);
+                return;
+            }
         }
         for (int i = 0; i < inputBuffer.Length; i++)
         {
@@ -273,7 +281,13 @@ public class FirFilter<S> : IFirFilter where S : unmanaged, IAudioSample<S>
 
     public void SetCoefficients(float[] _coefficients)
     {
+        int prevLen = coefficients.Length;
         coefficients = (float[])_coefficients.Clone();
+        if (prevLen != coefficients.Length)
+        {
+            delayLine = new S[coefficients.Length];
+            delayLineIndex = 0;
+        }
     }
 }
 
@@ -366,8 +380,16 @@ public class DelayEffect<S> : IDelayEffect where S : unmanaged, IAudioSample<S>
     {
         if (!update && lastBuffer != null)
         {
-            lastBuffer.CopyTo(samples);
-            return;
+            // check if buffer size changed
+            if (lastBuffer.Length != samples.Length)
+            {
+                lastBuffer = null;
+            }
+            else
+            {
+                lastBuffer.CopyTo(samples);
+                return;
+            }
         }
         ProcessLarge(samples, dryWet, feedback);
         if (update || lastBuffer == null)

--- a/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
@@ -33,13 +33,15 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             {
                 buffer.Fill(default(S));
                 // clear filters here?
-                _controller.Clear();
+                lock (_controller)
+                    _controller.Clear();
                 return;
             }
 
             AudioInput.Read(buffer, simulator);
 
-            _controller.Process(buffer, simulator.SampleRate, LowFrequency, HighFrequency, Resonance);
+            lock (_controller)
+                _controller.Process(buffer, simulator.SampleRate, LowFrequency, HighFrequency, Resonance);
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
@@ -33,13 +33,19 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             {
                 buffer.Fill(default(S));
                 // clear filters here?
-                _controller.Clear();
+                lock (_controller)
+                {
+                    _controller.Clear();
+                }
                 return;
             }
 
             AudioInput.Read(buffer, simulator);
 
-            _controller.Process(buffer, simulator.SampleRate, LowPass, Frequency, Resonance);
+            lock (_controller)
+            {
+                _controller.Process(buffer, simulator.SampleRate, LowPass, Frequency, Resonance);
+            }
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/Delay.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/Delay.cs
@@ -9,7 +9,6 @@ using Elements.Core;
 using System.Collections.Generic;
 using System.Linq;
 using Awwdio;
-using Valve.VR;
 
 namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 {

--- a/ProjectObsidian/ProtoFlux/Audio/Delay.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/Delay.cs
@@ -37,30 +37,43 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             if (!IsActive || AudioInput == null || !AudioInput.IsActive)
             {
                 buffer.Fill(default(S));
-                delays.Clear();
+                lock (delays)
+                    delays.Clear();
                 return;
             }
 
             AudioInput.Read(buffer, simulator);
 
-            if (!delays.TryGetValue(typeof(S), out var delay))
+            object delay;
+            lock (delays)
             {
-                delay = new DelayEffect<S>(delayMilliseconds, Engine.Current.AudioSystem.SampleRate);
-                delays.Add(typeof(S), delay);
-                UniLog.Log("Created new delay");
+                if (!delays.TryGetValue(typeof(S), out delay))
+                {
+                    delay = new DelayEffect<S>(delayMilliseconds, Engine.Current.AudioSystem.SampleRate);
+                    delays.Add(typeof(S), delay);
+                    UniLog.Log("Created new delay");
+                }
             }
 
-            if (!updateBools.TryGetValue(typeof(S), out bool update))
+            bool update;
+            lock (updateBools)
             {
-                update = true;
-                updateBools[typeof(S)] = update;
+                if (!updateBools.TryGetValue(typeof(S), out update))
+                {
+                    update = true;
+                    updateBools[typeof(S)] = update;
+                }
             }
 
-            ((DelayEffect<S>)delay).Process(buffer, DryWet, feedback, update);
+            lock ((DelayEffect<S>)delay)
+            {
+                ((DelayEffect<S>)delay).Process(buffer, DryWet, feedback, update);
+            }
 
             if (update)
             {
-                updateBools[typeof(S)] = false;
+                lock (updateBools)
+                    updateBools[typeof(S)] = false;
             }
         }
 
@@ -70,7 +83,8 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             {
                 foreach (var key in updateBools.Keys.ToArray())
                 {
-                    updateBools[key] = true;
+                    lock (updateBools)
+                        updateBools[key] = true;
                 }
             };
         }

--- a/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
@@ -86,8 +86,7 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                 if (!updateBools.TryGetValue(typeof(S), out update))
                 {
                     update = true;
-                    lock (updateBools)
-                        updateBools[typeof(S)] = update;
+                    updateBools[typeof(S)] = update;
                 }
             }
 

--- a/ProjectObsidian/ProtoFlux/Audio/Reverb.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/Reverb.cs
@@ -9,16 +9,13 @@ using System.Collections.Generic;
 using SharpPipe;
 using System.Linq;
 using Awwdio;
+using Obsidian.Elements;
 
 namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 {
     public class ReverbProxy : ProtoFluxEngineProxy, Awwdio.IAudioDataSource, IWorldAudioDataSource
     {
         public IWorldAudioDataSource AudioInput;
-
-        public Dictionary<Type, object> reverbs = new();
-
-        public Dictionary<Type, bool> updateBools = new();
 
         public ZitaParameters parameters;
 
@@ -30,73 +27,23 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         private ZitaParameters defaultParameters = new ZitaParameters();
 
-        public Dictionary<Type, object> lastBuffers = new();
+        public ReverbController _controller = new();
 
         public void Read<S>(Span<S> buffer, AudioSimulator simulator) where S : unmanaged, IAudioSample<S>
         {
             if (!IsActive || AudioInput == null || !AudioInput.IsActive || parameters.Equals(defaultParameters))
             {
                 buffer.Fill(default(S));
-                lock (reverbs)
-                    reverbs.Clear();
+                lock (_controller)
+                    _controller.Clear();
                 return;
             }
 
             AudioInput.Read(buffer, simulator);
 
-            object reverb;
-            lock (reverbs)
+            lock (_controller)
             {
-                if (!reverbs.TryGetValue(typeof(S), out reverb))
-                {
-                    reverb = new BufferReverber<S>(Engine.Current.AudioSystem.SampleRate, parameters);
-                    reverbs.Add(typeof(S), reverb);
-                    UniLog.Log("Created new reverb");
-                }
-            }
-
-            bool update;
-            lock (updateBools)
-            {
-                if (!updateBools.TryGetValue(typeof(S), out update))
-                {
-                    update = true;
-                    updateBools[typeof(S)] = update;
-                }
-            }
-
-            bool lastBufferIsNull = false;
-            if (!lastBuffers.TryGetValue(typeof(S), out var lastBuffer))
-            {
-                lastBufferIsNull = true;
-            }
-
-            if (!update && !lastBufferIsNull)
-            {
-                // check if buffer size changed
-                if (((S[])lastBuffer).Length != buffer.Length)
-                {
-                    lastBufferIsNull = true;
-                }
-                else
-                {
-                    ((S[])lastBuffer).CopyTo(buffer);
-                    return;
-                }
-            }
-
-            lock ((BufferReverber<S>)reverb)
-            {
-                ((BufferReverber<S>)reverb).ApplyReverb(buffer);
-            }
-
-            if (update || lastBufferIsNull)
-            {
-                lock (updateBools)
-                    updateBools[typeof(S)] = false;
-                lastBuffer = buffer.ToArray();
-                lock (lastBuffers)
-                    lastBuffers[typeof(S)] = lastBuffer;
+                _controller.Process(buffer, parameters);
             }
         }
 
@@ -104,10 +51,12 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
         {
             Engine.AudioSystem.AudioUpdate += () =>
             {
-                foreach (var key in updateBools.Keys.ToArray())
+                lock (_controller)
                 {
-                    lock (updateBools)
-                        updateBools[key] = true;
+                    foreach (var key in _controller.updateBools.Keys.ToArray())
+                    {
+                        _controller.updateBools[key] = true;
+                    }
                 }
             };
         }
@@ -206,7 +155,8 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
             proxy.parameters = Parameters.Evaluate(context);
             if (!proxy.parameters.Equals(lastParameters))
             {
-                proxy.reverbs.Clear();
+                lock (proxy._controller)
+                    proxy._controller.Clear();
             }
             lastParameters = proxy.parameters;
         }


### PR DESCRIPTION
Awwdio uses multithreading so these thread locks are necessary to keep things working, also account for buffers being resized on the fly