### PR TITLE
Optimize audio nodes and components

### DIFF
--- a/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/BandPassFilterNode.cs
@@ -29,19 +29,23 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         public void Read<S>(Span<S> buffer, AudioSimulator simulator) where S : unmanaged, IAudioSample<S>
         {
-            if (!IsActive || AudioInput == null)
-            {
-                buffer.Fill(default(S));
-                // clear filters here?
-                lock (_controller)
-                    _controller.Clear();
-                return;
-            }
-
-            AudioInput.Read(buffer, simulator);
-
             lock (_controller)
+            {
+                if (AudioInput == null)
+                {
+                    _controller.Clear();
+                }
+                if (!IsActive || AudioInput == null)
+                {
+                    buffer.Fill(default(S));
+                    return;
+                }
+
+                AudioInput.Read(buffer, simulator);
+
                 _controller.Process(buffer, simulator.SampleRate, LowFrequency, HighFrequency, Resonance);
+            }
+            
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/ButterworthFilterNode.cs
@@ -29,23 +29,23 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
 
         public void Read<S>(Span<S> buffer, AudioSimulator simulator) where S : unmanaged, IAudioSample<S>
         {
-            if (!IsActive || AudioInput == null)
+            lock (_controller)
             {
-                buffer.Fill(default(S));
-                // clear filters here?
-                lock (_controller)
+                if (AudioInput == null)
                 {
                     _controller.Clear();
                 }
-                return;
-            }
+                if (!IsActive || AudioInput == null)
+                {
+                    buffer.Fill(default(S));
+                    return;
+                }
 
-            AudioInput.Read(buffer, simulator);
+                AudioInput.Read(buffer, simulator);
 
-            lock (_controller)
-            {
                 _controller.Process(buffer, simulator.SampleRate, LowPass, Frequency, Resonance);
             }
+            
         }
     }
     [NodeCategory("Obsidian/Audio/Filters")]

--- a/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
+++ b/ProjectObsidian/ProtoFlux/Audio/FIR_Filter.cs
@@ -54,11 +54,6 @@ namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Audio
                     {
                         coeffs = Coefficients.ToArray();
                     }
-                    if (coeffs == null)
-                    {
-                        _controller.Clear();
-                        return;
-                    }
                     _controller.Coefficients = coeffs;
                     foreach (var filter in _controller.filters.Values)
                     {


### PR DESCRIPTION
This optimizes the memory usage of audio nodes. They don't allocate new arrays constantly anymore.

It also ensures the audio nodes and components always use `lock` so that only one thread can access the data at a time.

In addition, some logic was changed to avoid clearing data when it shouldn't have been cleared.

Finally, the reverb node now works when nothing is plugged into the `parameters` input. It uses the default output of the `ConstructZitaParameters` node in that case.