### PR TITLE
Remove feature list from readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,7 +50,7 @@ Upon doing this, start Resonite. Navigate to the Obsidian category in your dash 
 For a comprehensive guide, please refer to our [installation wiki](https://github.com/Xlinka/Project-Obsidian/wiki/Installation).
 
 ## Features
-The detailed feature list is available in the [wiki](https://github.com/Xlinka/Project-Obsidian/wiki/ProtoFlux-Nodes).
+The detailed feature list is available in the [wiki](https://github.com/Xlinka/Project-Obsidian/wiki/).
 
 
 ## Project Obsidian プラグインのインストール


### PR DESCRIPTION
Remove feature list from readme because it's already in the wiki and there's no need to duplicate it