### PR TITLE
Add Ceil/Floor/Round To Interval nodes and SlotToBodyNode

### DIFF
--- a/ProjectObsidian/ProtoFlux/Math/CeilToInterval_Double.cs
+++ b/ProjectObsidian/ProtoFlux/Math/CeilToInterval_Double.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Ceil To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class CeilToInterval_Double : ValueFunctionNode<FrooxEngineContext, double>
+    {
+        public ValueInput<double> Value;
+        public ValueInput<double> Interval;
+
+        protected override double Compute(FrooxEngineContext context)
+        {
+            double interval = Interval.Evaluate(context);
+            return MathX.Ceil(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Math/CeilToInterval_Float.cs
+++ b/ProjectObsidian/ProtoFlux/Math/CeilToInterval_Float.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Ceil To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class CeilToInterval_Float : ValueFunctionNode<FrooxEngineContext, float>
+    {
+        public ValueInput<float> Value;
+        public ValueInput<float> Interval;
+
+        protected override float Compute(FrooxEngineContext context)
+        {
+            float interval = Interval.Evaluate(context);
+            return MathX.Ceil(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Math/FloorToInterval_Double.cs
+++ b/ProjectObsidian/ProtoFlux/Math/FloorToInterval_Double.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Floor To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class FloorToInterval_Double : ValueFunctionNode<FrooxEngineContext, double>
+    {
+        public ValueInput<double> Value;
+        public ValueInput<double> Interval;
+
+        protected override double Compute(FrooxEngineContext context)
+        {
+            double interval = Interval.Evaluate(context);
+            return MathX.Floor(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Math/FloorToInterval_Float.cs
+++ b/ProjectObsidian/ProtoFlux/Math/FloorToInterval_Float.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Floor To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class FloorToInterval_Float : ValueFunctionNode<FrooxEngineContext, float>
+    {
+        public ValueInput<float> Value;
+        public ValueInput<float> Interval;
+
+        protected override float Compute(FrooxEngineContext context)
+        {
+            float interval = Interval.Evaluate(context);
+            return MathX.Floor(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Math/RoundToInterval_Double.cs
+++ b/ProjectObsidian/ProtoFlux/Math/RoundToInterval_Double.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Round To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class RoundToInterval_Double : ValueFunctionNode<FrooxEngineContext, double>
+    {
+        public ValueInput<double> Value;
+        public ValueInput<double> Interval;
+
+        protected override double Compute(FrooxEngineContext context)
+        {
+            double interval = Interval.Evaluate(context);
+            return MathX.Round(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Math/RoundToInterval_Float.cs
+++ b/ProjectObsidian/ProtoFlux/Math/RoundToInterval_Float.cs
@@ -1,0 +1,21 @@
+using Elements.Core;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using FrooxEngine.ProtoFlux;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Math
+{
+    [NodeName("Round To Interval")]
+    [NodeCategory("Obsidian/Math")]
+    public class RoundToInterval_Float : ValueFunctionNode<FrooxEngineContext, float>
+    {
+        public ValueInput<float> Value;
+        public ValueInput<float> Interval;
+
+        protected override float Compute(FrooxEngineContext context)
+        {
+            float interval = Interval.Evaluate(context);
+            return MathX.Round(Value.Evaluate(context) / interval) * interval;
+        }
+    }
+}

--- a/ProjectObsidian/ProtoFlux/Users/Avatar/SlotToBodyNode.cs
+++ b/ProjectObsidian/ProtoFlux/Users/Avatar/SlotToBodyNode.cs
@@ -1,0 +1,40 @@
+using FrooxEngine;
+using FrooxEngine.ProtoFlux;
+using ProtoFlux.Core;
+using ProtoFlux.Runtimes.Execution;
+using Renderite.Shared;
+
+namespace ProtoFlux.Runtimes.Execution.Nodes.Obsidian.Users.Avatar
+{
+    [NodeCategory("Obsidian/Avatar")]
+    public class SlotToBodyNode : VoidNode<FrooxEngineContext>
+    {
+        public ObjectArgument<Slot> Slot;
+
+        public readonly ValueOutput<BodyNode> Node;
+
+        protected override void ComputeOutputs(FrooxEngineContext context)
+        {
+            Slot slot = 0.ReadObject<Slot>(context);
+            BodyNode result = BodyNode.NONE;
+
+            if (slot != null && !slot.IsRemoved)
+            {
+                BipedRig rig = slot.GetComponentInParents<BipedRig>();
+                if (rig != null)
+                {
+                    result = rig.GetBoneType(slot);
+                }
+            }
+
+            Node.Write(result, context);
+        }
+
+        public SlotToBodyNode()
+        {
+            Node = new ValueOutput<BodyNode>(this);
+        }
+    }
+}
+
+


### PR DESCRIPTION
- Adds RoundToInterval, FloorToInterval, and CeilToInterval ProtoFlux nodes (float & double variants) under Obsidian/Math — rounds a value to the nearest multiple of a given interval, useful for grid snapping and value binning

- Adds SlotToBodyNode under Obsidian/Avatar — resolves a slot to its BodyNode enum value by walking up to the nearest BipedRig